### PR TITLE
新增项目类型支持：驱动

### DIFF
--- a/Mile.Project.Cpp.Default.props
+++ b/Mile.Project.Cpp.Default.props
@@ -12,7 +12,7 @@
   <PropertyGroup Label="Globals">
     <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
     <CleanImport>true</CleanImport>
     <MileProjectBuildDate>$([System.DateTime]::Now.ToString("yyyyMMdd"))</MileProjectBuildDate>
     <MileProjectPreprocessorDefinitions></MileProjectPreprocessorDefinitions>
@@ -66,16 +66,37 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
+    <CharacterSet>Unicode</CharacterSet>
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+
     <ConfigurationType>Application</ConfigurationType>
     <ConfigurationType Condition="'$(MileProjectType)'=='DynamicLibrary'">DynamicLibrary</ConfigurationType>
     <ConfigurationType Condition="'$(MileProjectType)'=='StaticLibrary'">StaticLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType Condition="'$(MileProjectType)'=='StaticLibraryForDriver'">StaticLibrary</ConfigurationType>
+    <ConfigurationType Condition="'$(MileProjectType)'=='WDMDriver'">Driver</ConfigurationType>
+    <ConfigurationType Condition="'$(MileProjectType)'=='KMDFDriver'">Driver</ConfigurationType>
+    <ConfigurationType Condition="'$(MileProjectType)'=='UMDFDriver'">DynamicLibrary</ConfigurationType>
+
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <PlatformToolset Condition="'$(MileProjectType)' == 'StaticLibraryForDriver'">WindowsKernelModeDriver10.0</PlatformToolset>
+    <PlatformToolset Condition="'$(MileProjectType)' == 'WDMDriver'">WindowsKernelModeDriver10.0</PlatformToolset>
+    <PlatformToolset Condition="'$(MileProjectType)' == 'KMDFDriver'">WindowsKernelModeDriver10.0</PlatformToolset>
+    <PlatformToolset Condition="'$(MileProjectType)' == 'UMDFDriver'">WindowsUserModeDriver10.0</PlatformToolset>
     <PlatformToolset Condition="'$(MileProjectUseClangCLToolset)' == 'true'">ClangCL</PlatformToolset>
-    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
-    <CharacterSet>Unicode</CharacterSet>
+
     <UseDebugLibraries Condition="'$(Configuration)'=='Debug'">true</UseDebugLibraries>
     <UseDebugLibraries Condition="'$(Configuration)'=='Release'">false</UseDebugLibraries>
     <WholeProgramOptimization Condition="'$(Configuration)'=='Release'">true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="('$(MileProjectType)'=='WDMDriver') Or ('$(MileProjectType)'=='KMDFDriver') Or ('$(MileProjectType)'=='UMDFDriver') Or ('$(MileProjectType)'=='StaticLibraryForDriver')">
+    <DriverType>KMDF</DriverType>
+    <DriverType Condition="'$(MileProjectType)' == 'WDMDriver'">WDM</DriverType>
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <DebuggerFlavor Condition="'$(MileProjectType)' == 'UMDFDriver'">DbgengRemoteDebugger</DebuggerFlavor>
+    <TargetVersion>Windows10</TargetVersion>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <ALLOW_DATE_TIME>1</ALLOW_DATE_TIME>
+    <UMDF_VERSION_MAJOR Condition="'$(MileProjectType)' == 'UMDFDriver'">2</UMDF_VERSION_MAJOR>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
 </Project>

--- a/Mile.Project.Cpp.props
+++ b/Mile.Project.Cpp.props
@@ -12,6 +12,9 @@
   <PropertyGroup>
     <LinkIncremental Condition="'$(Configuration)'=='Debug'">true</LinkIncremental>
     <LinkIncremental Condition="'$(Configuration)'=='Release'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(MileProjectType)'=='WDMDriver'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(MileProjectType)'=='KMDFDriver'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(MileProjectType)'=='UMDFDriver'">false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
     <IncludePath>$(MSBuildThisFileDirectory);$(IncludePath)</IncludePath>
   </PropertyGroup>
@@ -30,6 +33,7 @@
       <PreprocessorDefinitions Condition="'$(MileProjectType)'=='WindowsApplication'">_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(MileProjectType)'=='DynamicLibrary'">_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(MileProjectType)'=='StaticLibrary'">_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(MileProjectType)'=='StaticLibraryForDriver'">_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
@@ -100,6 +104,14 @@
     <Link>
       <CETCompat Condition="'$(Platform)'=='Win32' Or '$(Platform)'=='x64'">true</CETCompat>
     </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="('$(MileProjectType)'=='WDMDriver') Or ('$(MileProjectType)'=='KMDFDriver') Or ('$(MileProjectType)'=='UMDFDriver') Or ('$(MileProjectType)'=='StaticLibraryForDriver')">
+    <ClCompile>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+    </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemGroup>
     <PackageReference Include="VC-LTL" Condition="'$(MileProjectEnableVCLTLSupport)' == 'true'">

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -40,6 +40,30 @@ hope it can help you develop applications with Mile.Project.Windows.
 <MileProjectType>StaticLibrary</MileProjectType>
 ```
 
+- If the project is a WDM driver project.
+
+```
+<MileProjectType>WDMDriver</MileProjectType>
+```
+
+- If the project is a KMDF driver project.
+
+```
+<MileProjectType>KMDFDriver</MileProjectType>
+```
+
+- If the project is a UMDF driver project.
+
+```
+<MileProjectType>UMDFDriver</MileProjectType>
+```
+
+- If the project is a static library for driver project.
+
+```
+<MileProjectType>StaticLibraryForDriver</MileProjectType>
+```
+
 ### How to define the manifest file in the "Globals" label property group.
 
 ```


### PR DESCRIPTION
### 支持的驱动类型：
WDM、KMDF、UMDF、StaticLibraryForDriver

### 存在的已知问题：
通过 `Directory.Build.props` 设置的 `OutDir/IntDir` 没有生效。实测要在 `$(VCTargetsPath)\Microsoft.Cpp.props` 后面的位置去设置才会生效。
> 仅在驱动项目存在，且使用默认生成的vcxproj不存在这个问题，**原因未知**。